### PR TITLE
added clarification to W9 step

### DIFF
--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -69,11 +69,15 @@
         </div>
     {% endif %}
 
-    {% if band.completed_w9 %}
+    {% if band.completed_w9 or not band.payment %}
         <div class="row">
             <label class="col-sm-2 control-label">Completed W9:</label>
             <div class="col-sm-6">
-                <a href="{{ band.w9_url }}">Click here to view the band's uploaded W9</a>
+                {% if band.completed_w9 %}
+                    <a href="{{ band.w9_url }}">Click here to view the band's uploaded W9</a>
+                {% else %}
+                    This band isn't being paid and thus doesn't need a W9.
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -41,7 +41,7 @@
             <td>{{ group.band.completed_panel|yesno:"Y," }}</td>
             <td>{{ group.band.completed_bio|yesno:"Y," }}</td>
             <td>{{ group.band.completed_agreement|yesno:"Y," }}</td>
-            <td>{{ group.band.completed_w9|yesno:"Y," }}</td>
+            <td>{% if group.band.completed_w9 or not group.band.payment %}Y{% endif %}</td>
             <td>{{ group.band.merch|yesno:"Y," }}</td>
             <td>{{ group.band.charity|yesno:"Y," }}</td>
             <td>{{ group.band.all_badges_claimed|yesno:"Y," }}</td>


### PR DESCRIPTION
Admins were getting confused because a band which doesn't need a W9 was showing up with their "W9" step unchecked, which made it seem like there was work that needed to be done.  I've changed it so that a check shows up for that step for bands not receiving payment who therefore don't need a W9.  I also added a note about this on the Band Info admin page.