### PR TITLE
non-bands no longer show up as Y in the W9 column

### DIFF
--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -41,7 +41,7 @@
             <td>{{ group.band.completed_panel|yesno:"Y," }}</td>
             <td>{{ group.band.completed_bio|yesno:"Y," }}</td>
             <td>{{ group.band.completed_agreement|yesno:"Y," }}</td>
-            <td>{% if group.band.completed_w9 or not group.band.payment %}Y{% endif %}</td>
+            <td>{% if group.band %}{% if group.band.completed_w9 or not group.band.payment %}Y{% endif %}{% endif %}</td>
             <td>{{ group.band.merch|yesno:"Y," }}</td>
             <td>{{ group.band.charity|yesno:"Y," }}</td>
             <td>{{ group.band.all_badges_claimed|yesno:"Y," }}</td>


### PR DESCRIPTION
Minor tweak to the W9 stuff I implemented earlier today.  While technically it is true that non-bands have nothing left to do w.r.t. a W9, it's confusing and misleading to list a Y in that column.