### PR TITLE
split up code for readability

### DIFF
--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -31,13 +31,12 @@ class Root:
                 band.event_id = event_id
             raise HTTPRedirect('index?message={}{}', band.group.name, ' data uploaded')
 
+        events = session.query(Event).filter_by(location=c.CONCERTS).order_by(Event.start_time).all()
+
         return {
             'band': band,
             'message': message,
-            'events': [
-                (event.id, event.name)
-                for event in session.query(Event).filter_by(location=c.CONCERTS).order_by(Event.start_time).all()
-            ]
+            'events': [(event.id, event.name) for event in events]
         }
 
     @csv_file

--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -32,7 +32,6 @@ class Root:
             raise HTTPRedirect('index?message={}{}', band.group.name, ' data uploaded')
 
         events = session.query(Event).filter_by(location=c.CONCERTS).order_by(Event.start_time).all()
-
         return {
             'band': band,
             'message': message,


### PR DESCRIPTION
This was crashing and took a while to figure out what exactly was going wrong. (we didn't have ```concerts``` in ```[event_locations]```)

Splitting up the code this way means if someone runs into the same issue later when trying to setup a new uber instance, it'll be more obvious what's going wrong.

We probably should check for c.CONCERTS in c.EVENT_LOCATION_OPTS, maybe will do that in a while.