### PR TITLE
minor text fixes for agreement

### DIFF
--- a/bands/templates/bands/agreement-base.html
+++ b/bands/templates/bands/agreement-base.html
@@ -6,12 +6,12 @@
     Band agreement for <strong>{{ band.group.name }}</strong> to perform at {{ c.EVENT_NAME_AND_YEAR }}!
     </h2>
     <p>
-        {{ c.EVENT_NAME_AND_YEAR }} will be held at <strong>{{ c.EVENT_VENUE }}: {{ c.EVENT_VENUE_ADDRESS }},</strong>
-        from <strong>{{ c.EPOCH|datetime:"%B %d" }} - {{ c.ESCHATON|datetime:"%d, %Y" }}.</strong>
-            <br>
+        {{ c.EVENT_NAME_AND_YEAR }} will be held on <strong>{{ c.EPOCH|datetime:"%B %d" }} - {{ c.ESCHATON|datetime:"%d, %Y" }}.</strong><br>
+        Venue Address: <strong>{{ c.EVENT_VENUE }}: {{ c.EVENT_VENUE_ADDRESS }}</strong>
+            <br><br>
         Performers are encouraged to attend the full event and interact with staff, fellow performers, and attendees
         in a relaxed environment.
-            <br>
+            <br><br>
         If performers will not be attending the full event, we ask that they inform us in advance so we may better
         allocate sleeping arrangements.
     </p>
@@ -24,10 +24,10 @@
     <p>
         Performance time and date for {{ band.group.name }} to be determined, and will be provided prior to the event
         as an update to this document.
-            <br>
+            <br><br>
         Performer will be provided with <strong>{{ band.estimated_loadin_minutes }} minutes</strong>,
         of set up and line-check, followed by <strong>{{ band.performance_minutes }} minutes</strong> for performance.
-            <br>
+            <br><br>
         {% block band_text_timer %}
         These time-frames will be enforced, via an on-stage timer, to ensure that performances occur in a timely fashion.
         {% endblock band_text_timer %}
@@ -148,7 +148,7 @@
     <div class="form-group">
         <label class="col-sm-2 control-label">Parking:</label>
         <div class="col-sm-6">
-            {% checkbox band_info.bringing_vehicle %} We will be parking at MAGFest.
+            {% checkbox band_info.bringing_vehicle %} We will be parking at {{ c.EVENT_NAME }}.
         </div>
     </div>
 

--- a/bands/templates/bands/agreement-base.html
+++ b/bands/templates/bands/agreement-base.html
@@ -25,8 +25,8 @@
         Performance time and date for {{ band.group.name }} to be determined, and will be provided prior to the event
         as an update to this document.
             <br><br>
-        Performer will be provided with <strong>{{ band.estimated_loadin_minutes }} minutes</strong>,
-        of set up and line-check, followed by <strong>{{ band.performance_minutes }} minutes</strong> for performance.
+        Performer will be provided with <strong>{{ band.estimated_loadin_minutes }} minutes</strong>
+        for setup and line-check, followed by <strong>{{ band.performance_minutes }} minutes</strong> for performance.
             <br><br>
         {% block band_text_timer %}
         These time-frames will be enforced, via an on-stage timer, to ensure that performances occur in a timely fashion.


### PR DESCRIPTION
the double ```<br>```s will go away with the real styling, works for now
fix hardcoded text, re-arrange small stuff to make things look a little nicer