### PR TITLE
change soundcheck / performance times to more real-world defaults

### DIFF
--- a/bands/configspec.ini
+++ b/bands/configspec.ini
@@ -6,6 +6,9 @@ allowed_w9_extensions = string_list(default=list("pdf", "png", "gif", "jpg", "jp
 allowed_bio_pic_extensions = string_list(default=list("png", "gif", "jpg", "jpeg"))
 allowed_stage_plot_extensions = string_list(default=list("zip", "pdf", "png", "gif", "jpg", "jpeg", "doc", "docx"))
 
+default_loadin_minutes = integer(default=20)
+default_performance_minutes = integer(default=40)
+
 
 [dates]
 auction_start = string(default="2016-02-21 11")

--- a/bands/models.py
+++ b/bands/models.py
@@ -28,8 +28,8 @@ class Band(MagModel):
 
     payment = Column(Integer, default=0, admin_only=True)
     vehicles = Column(Integer, default=1, admin_only=True)
-    estimated_loadin_minutes = Column(Integer, default=60, admin_only=True)
-    estimated_performance_minutes = Column(Integer, default=60, admin_only=True)
+    estimated_loadin_minutes = Column(Integer, default=20, admin_only=True)
+    estimated_performance_minutes = Column(Integer, default=40, admin_only=True)
 
     @property
     def all_badges_claimed(self):

--- a/bands/models.py
+++ b/bands/models.py
@@ -28,8 +28,8 @@ class Band(MagModel):
 
     payment = Column(Integer, default=0, admin_only=True)
     vehicles = Column(Integer, default=1, admin_only=True)
-    estimated_loadin_minutes = Column(Integer, default=20, admin_only=True)
-    estimated_performance_minutes = Column(Integer, default=40, admin_only=True)
+    estimated_loadin_minutes = Column(Integer, default=c.DEFAULT_LOADIN_MINUTES, admin_only=True)
+    estimated_performance_minutes = Column(Integer, default=c.DEFAULT_PERFORMANCE_MINUTES, admin_only=True)
 
     @property
     def all_badges_claimed(self):


### PR DESCRIPTION
- this should probably be a config setting because magprime will be very different from the other events (due to 2 stage flip flopping)
- this is a sensible default for regular 1-stage events