### PR TITLE
disable autofill of band performance length from schedule

### DIFF
--- a/bands/models.py
+++ b/bands/models.py
@@ -41,7 +41,7 @@ class Band(MagModel):
 
     @property
     def performance_minutes(self):
-        return self.event.minutes if self.event_id else self.estimated_performance_minutes
+        return self.estimated_performance_minutes
 
     @property
     def email(self):

--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -214,7 +214,7 @@
     </div>
 
     <div class="row">
-        <label class="col-sm-2 control-label">Load-In:</label>
+        <label class="col-sm-2 control-label">Load-In length:</label>
         <div class="col-sm-6">
             <input type="number" class="form-control" name="estimated_loadin_minutes" value="{{ band.estimated_loadin_minutes }}" />
             <p class="help-text">
@@ -223,9 +223,8 @@
         </div>
     </div>
 
-    {% if not band.event_id %}
     <div class="row">
-        <label class="col-sm-2 control-label">Performance Time:</label>
+        <label class="col-sm-2 control-label">Performance length:</label>
         <div class="col-sm-6">
             <input type="number" class="form-control" name="estimated_performance_minutes" value="{{ band.estimated_performance_minutes }}" />
             <p class="help-text">
@@ -233,7 +232,6 @@
             </p>
         </div>
     </div>
-    {% endif %}
 
     <div class="row">
         <label class="col-sm-2 control-label">Event:</label>


### PR DESCRIPTION
- calculations were resulting in incorrect times due to not subtracting setup time
- this calculation also would have broken for bands starting at non-schedule interval times (at :00 or :30 on the hour)
- this is still not a bad idea, but, the schedule itself needs to support bands starting at arbitrary times, and currently doesn't
- also, for main magfest, we usually setup one block for all bands called i.e. "Friday Concerts" so the band plugin would think the performance  time was 6 hours for each band

fixes #39