### PR TITLE
updated: add band property to Attendee band plugin mixin

### DIFF
--- a/bands/models.py
+++ b/bands/models.py
@@ -13,7 +13,7 @@ class Group:
 @Session.model_mixin
 class Attendee:
     @property
-    def associated_band(self):
+    def band(self):
         """
         :return: The Band this attendee is part of (either as a performer or a +1 comp), or None if not
         """

--- a/bands/models.py
+++ b/bands/models.py
@@ -13,8 +13,11 @@ class Group:
 @Session.model_mixin
 class Attendee:
     @property
-    def auto_food_extra(self):
-        return self.group and self.group.band is not None
+    def associated_band(self):
+        """
+        :return: The Band this attendee is part of (either as a performer or a +1 comp), or None if not
+        """
+        return self.group and self.group.band
 
 
 @Session.model_mixin

--- a/bands/models.py
+++ b/bands/models.py
@@ -9,6 +9,12 @@ def extension(filename):
 class Group:
     band = relationship('Band', backref='group', uselist=False)
 
+@Session.model_mixin
+class Attendee:
+    @property
+    def auto_food_extra(self):
+        return self.group and self.group.band is not None
+
 
 @Session.model_mixin
 class Event:

--- a/bands/models.py
+++ b/bands/models.py
@@ -9,6 +9,7 @@ def extension(filename):
 class Group:
     band = relationship('Band', backref='group', uselist=False)
 
+
 @Session.model_mixin
 class Attendee:
     @property


### PR DESCRIPTION
implement 'band' property for Attendee in order to tell if this attendee is associated with a band

useful for a bunch of stuff, we're going to use it in magstock plugin to tell it that bands get free food.