### PR TITLE
Add band start times to band agreement

### DIFF
--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -240,6 +240,10 @@
                 <option value="">Pick an Event</option>
                 {% options events band.event_id %}
             </select>
+            <p class="help-text">
+                If not set, the band agreement will say "date and time information coming soon"<br/>
+                If this is set, the band agreement will reflect the start time of the event on the schedule.
+            </p>
         </div>
     </div>
 

--- a/bands/templates/bands/agreement-base.html
+++ b/bands/templates/bands/agreement-base.html
@@ -22,8 +22,14 @@
         Performance
     </h3>
     <p>
+        {% if not band.event or not band.event.start_time %}
         Performance time and date for {{ band.group.name }} to be determined, and will be provided prior to the event
         as an update to this document.
+        {% else %}
+        Performance time and date for {{ band.group.name }} will be
+        <strong>{{ band.event.start_time|datetime:"%A, %B %d at %I:%M %p (%Z)" }}</strong>.
+        Please arrive at the stage, with all band members ready to play and performance equipment present, at least 1 hour before this time.
+        {% endif %}
             <br><br>
         Performer will be provided with <strong>{{ band.estimated_loadin_minutes }} minutes</strong>
         for setup and line-check, followed by <strong>{{ band.performance_minutes }} minutes</strong> for performance.


### PR DESCRIPTION
Per Mike P's request

- If an event is associated with the band, then the contract will reflect that time
- If there is no event associated with the band, then the contract will say "more info coming later on start time"
- Add some helpful text