### PR TITLE
Use relative urls

### DIFF
--- a/bands/models.py
+++ b/bands/models.py
@@ -96,7 +96,7 @@ class BandBio(MagModel):
 
     @property
     def pic_url(self):
-        return '{}/bands/view_bio_pic?id={}'.format(c.URL_BASE, self.band.id) if self.uploaded_pic else ''
+        return '../bands/view_bio_pic?id={}'.format(self.band.id) if self.uploaded_pic else ''
 
     @property
     def pic_fpath(self):
@@ -144,7 +144,7 @@ class BandStagePlot(MagModel):
 
     @property
     def url(self):
-        return '{}/bands/view_stage_plot?id={}'.format(c.URL_BASE, self.band.id) if self.uploaded_file else ''
+        return '../bands/view_stage_plot?id={}'.format(self.band.id) if self.uploaded_file else ''
 
     @property
     def fpath(self):

--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -51,13 +51,19 @@ class Root:
             'Charity Answer', 'Charity Donation'
         ])
         for band in session.query(Band).all():
+            bio_url = getattr(band.bio, 'pic_url', '')
+            taxes_url = getattr(band.taxes, 'w9_url', '')
+            stageplot_url = getattr(band.stage_plot, 'url', '')
+            absolute_pic_url = build_uber_absolute_url(bio_url) if bio_url else ''
+            absolute_taxes_url = build_uber_absolute_url(taxes_url) if taxes_url else ''
+            absolute_stageplot_url = build_uber_absolute_url(stageplot_url) if stageplot_url else ''
             out.writerow([
                 band.group.name, band.email,
                 band.payment, band.vehicles, band.estimated_loadin_minutes, band.estimated_performance_minutes,
                 getattr(band.info, 'poc_phone', ''), getattr(band.info, 'performer_count', ''), getattr(band.info, 'bringing_vehicle', ''), getattr(band.info, 'vehicle_info', ''), getattr(band.info, 'arrival_time', ''),
-                getattr(band.bio, 'desc', ''), getattr(band.bio, 'website', ''), getattr(band.bio, 'facebook', ''), getattr(band.bio, 'twitter', ''), getattr(band.bio, 'other_social_media', ''), getattr(band.bio, 'pic_url', ''),
+                getattr(band.bio, 'desc', ''), getattr(band.bio, 'website', ''), getattr(band.bio, 'facebook', ''), getattr(band.bio, 'twitter', ''), getattr(band.bio, 'other_social_media', ''), absolute_pic_url,
                 getattr(band.panel, 'wants_panel', ''), getattr(band.panel, 'name', ''), getattr(band.panel, 'length', ''), getattr(band.panel, 'desc', ''), ' / '.join(getattr(band.panel, 'panel_tech_needs_labels', '')),
-                getattr(band.taxes, 'w9_url', ''), getattr(band.stage_plot, 'url', ''),
+                absolute_taxes_url, absolute_stageplot_url,
                 getattr(band.merch, 'selling_merch_label', ''),
                 getattr(band.charity, 'donating_label', ''), getattr(band.charity, 'desc', '')
             ])

--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -238,7 +238,7 @@
         <div class="col-sm-6">
             <select name="event_id" class="form-control">
                 <option value="">Pick an Event</option>
-                {% options events band.event_id %}
+                {{ options(events,band.event_id) }}
             </select>
             <p class="help-text">
                 If not set, the band agreement will say "date and time information coming soon"<br/>

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -29,7 +29,7 @@
     </thead>
     <tbody>
     {% for group in groups %}
-        <tr id="{{ group.id }}" class="{{ group.band|yesno:"band,nonband" }}">
+        <tr id="{{ group.id }}" class="{{ group.band|yesno("band,nonband") }}">
             <td><a href="../groups/form?id={{ group.id }}">{{ group.name }}</a></td>
             <td class="band">
                 {% if group.band %}
@@ -38,14 +38,14 @@
                     <button onClick="markAsBand('{{ group.id }}')">Mark as a Band</button>
                 {% endif %}
             </td>
-            <td>{{ group.band.panel.completed|yesno:"Y," }}</td>
-            <td>{{ group.band.bio.completed|yesno:"Y," }}</td>
-            <td>{{ group.band.info.completed|yesno:"Y," }}</td>
+            <td>{{ group.band.panel.completed|yesno("Y,") }}</td>
+            <td>{{ group.band.bio.completed|yesno("Y,") }}</td>
+            <td>{{ group.band.info.completed|yesno("Y,") }}</td>
             <td>{% if group.band %}{% if group.band.taxes.completed or not group.band.payment %}Y{% endif %}{% endif %}</td>
-            <td>{{ group.band.merch.completed|yesno:"Y," }}</td>
-            <td>{{ group.band.charity.completed|yesno:"Y," }}</td>
-            <td>{{ group.band.all_badges_claimed|yesno:"Y," }}</td>
-            <td>{{ group.band.stage_plot.completed|yesno:"Y," }}</td>
+            <td>{{ group.band.merch.completed|yesno("Y,") }}</td>
+            <td>{{ group.band.charity.completed|yesno("Y,") }}</td>
+            <td>{{ group.band.all_badges_claimed|yesno("Y,") }}</td>
+            <td>{{ group.band.stage_plot.completed|yesno("Y,") }}</td>
         </tr>
     {% endfor %}
     </tbody>

--- a/bands/templates/bands/agreement-base.html
+++ b/bands/templates/bands/agreement-base.html
@@ -154,7 +154,7 @@
     <div class="form-group">
         <label class="col-sm-2 control-label">Parking:</label>
         <div class="col-sm-6">
-            {% checkbox band_info.bringing_vehicle %} We will be parking at {{ c.EVENT_NAME }}.
+            {{ macros.checkbox(band_info, 'bringing_vehicle') }} We will be parking at {{ c.EVENT_NAME }}.
         </div>
     </div>
 

--- a/bands/templates/bands/charity.html
+++ b/bands/templates/bands/charity.html
@@ -20,7 +20,7 @@ Our auction starts on {{ c.AUCTION_START|datetime:"%A at %-H%p" }} and goes unti
     <input type="hidden" name="id" value="{{ band_charity.db_id }}" />
     <select name="donating">
         <option value="">Let us know whether you can donate anything</option>
-        {% options c.BAND_CHARITY_OPTS band_charity.donating %}
+        {{ options(c.BAND_CHARITY_OPTS,band_charity.donating) }}
     </select>
     <br/> <br/>
     <div id="donating_yes" style="display:none">

--- a/bands/templates/bands/merch.html
+++ b/bands/templates/bands/merch.html
@@ -36,7 +36,7 @@
     <input type="hidden" name="id" value="{{ band_merch.db_id }}" />
     <select name="selling_merch">
         <option value="">Tell us how you'd like to sell your merch</option>
-        {% options c.BAND_MERCH_OPTS band_merch.selling_merch %}
+        {{ options(c.BAND_MERCH_OPTS,band_merch.selling_merch) }}
     </select>
     <br/> <br/>
     {% if c.REQUIRE_DEDICATED_BAND_TABLE_PRESENCE %}

--- a/bands/templates/bands/panel.html
+++ b/bands/templates/bands/panel.html
@@ -28,7 +28,7 @@ our schedule to accommodate all requests, we definitely want to hear your ideas.
         <div class="col-sm-6" style="padding-top:7px">
             <select name="wants_panel">
                 <option value="">Do you want a panel?</option>
-                {% options c.BAND_PANEL_OPTS band_panel.wants_panel %}
+                {{ options(c.BAND_PANEL_OPTS,band_panel.wants_panel) }}
             </select>
         </div>
     </div>

--- a/bands/templates/bands/panel.html
+++ b/bands/templates/bands/panel.html
@@ -60,7 +60,7 @@ our schedule to accommodate all requests, we definitely want to hear your ideas.
     <div class="form-group panel-info">
         <label class="col-sm-2 control-label">Tech Needs:</label>
         <div class="col-sm-6">
-            {% checkgroup band_panel.tech_needs %}
+            {{ band_panel.html_checkgroup('tech_needs') }}
         </div>
     </div>
 


### PR DESCRIPTION
requires https://github.com/magfest/ubersystem/pull/1890

Make band plugin use relative URLs for purely web-based stuff, and use the new functionality in base ubersystem to create absolute urls when we have no other choice, such as for the CSV export of band information, or email text generation.