### PR TITLE
Stop setting band_info id to None every time

### DIFF
--- a/bands/site_sections/bands.py
+++ b/bands/site_sections/bands.py
@@ -9,7 +9,7 @@ class Root:
             'band': session.band(id)
         }
 
-    def agreement(self, session, band_id, id=None, message='', **params):
+    def agreement(self, session, band_id, message='', **params):
         band = session.band(band_id)
         band_info = session.band_info(params, restricted=True)
         if cherrypy.request.method == 'POST':


### PR DESCRIPTION
Fixes https://github.com/magfest/bands/issues/32. A leftover parameter in the function was resetting the band info's ID to None, making it try to create a new band_info object every time it was saved.