### PR TITLE
Remove base-admin.html

### DIFF
--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}{{ band.group.name }}{% endblock %}
 {% block content %}
 

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Band Admin{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.