### PR TITLE
Add page to decrease steps required to create band

### DIFF
--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -26,7 +26,7 @@ class Root:
             if not message:
                 group.auto_recalc = False
                 session.add(group)
-                message = session.assign_badges(group, params['badges'], new_ribbon_type=c.BAND, paid=c.NEED_NOT_PAY)
+                message = session.assign_badges(group, params.get('badges', 1), new_ribbon_type=c.BAND, paid=c.NEED_NOT_PAY)
             if not message:
                 session.commit()
                 leader = group.leader = group.attendees[0]

--- a/bands/templates/band_admin/add_band.html
+++ b/bands/templates/band_admin/add_band.html
@@ -1,72 +1,75 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Group Form{% endblock %}
 {% block content %}
-    <div class="panel panel-default">
-<div class="panel-body">
 
-<h2> Group Info </h2>
+<style>
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+</style>
 
-<div style="text-align:center">
-    <a href="index">Return to group list</a>
-</div>
-<form method="post" action="add_band" class="form-horizontal">
-{{ csrf_token() }}
-<input type="hidden" name="id" value="{{ group.db_id }}" />
-    <div class="form-group">
-    <label class="col-sm-2 control-label">Name of Group</label>
+<form method="post" action="add_band" class="form-horizontal" style="max-width: 738px;">
+  <h1>Band Info <small><a href="index">Return to band list</a></small></h1>
+
+  {{ csrf_token() }}
+  <input type="hidden" name="id" value="{{ group.db_id }}" />
+
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="name">Name of Group</label>
     <div class="col-sm-6">
-        <input class="focus" type="text" name="name" value="{{ group.name }}" />
+      <input class="focus form-control" type="text" id="name" name="name" value="{{ group.name }}" />
     </div>
-</div>
+  </div>
 
-    <div class="form-group">
-    <label class="col-sm-2 control-label">Badges</label>
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="badges">Badges</label>
     <div class="col-sm-6">
-        <select name="badges">
-            {{ int_options(1, c.MAX_GROUP_SIZE, group.badges) }}
-        </select>
-        {% if not group.is_new %}
-            [{{ group.badges_purchased }} badge(s) purchased]
-        {% endif %}
+      <select class="form-control" id="badges" name="badges">
+        {{ int_options(1, c.MAX_GROUP_SIZE, group.badges) }}
+      </select>
+      {% if not group.is_new %}
+      <p class="help-block">{{ group.badges_purchased }} badge{{group.badges_purchased|pluralize}} purchased</p>
+      {% endif %}
     </div>
-</div>
+  </div>
 
-{% include "groupextra.html" %}
+  {% include "groupextra.html" %}
 
-<div class="form-group">
-    <label class="col-sm-2 control-label">Admin Notes</label>
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="admin_notes">Admin Notes</label>
     <div class="col-sm-6">
-        <textarea name="admin_notes" rows="3" style="width:66%">{{ group.admin_notes }}</textarea>
+      <textarea class="form-control" id="admin_notes" name="admin_notes" rows="3">{{ group.admin_notes }}</textarea>
     </div>
-</div>
+  </div>
 
-    <h2>Leader Info</h2>
-<div class="form-group">
-    <label class="col-sm-2 control-label">First Name</label>
+  <h1>Leader Info</h1>
+
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="first_name">First Name</label>
     <div class="col-sm-6">
-        <input class="focus" type="text" name="first_name" value="{{ first_name }}" />
+      <input class="form-control" type="text" id="first_name" name="first_name" value="{{ group.leader.first_name or first_name }}" />
     </div>
-</div>
+  </div>
 
-<div class="form-group">
-    <label class="col-sm-2 control-label">Last Name</label>
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="last_name">Last Name</label>
     <div class="col-sm-6">
-        <input class="focus" type="text" name="last_name" value="{{ last_name }}" />
+      <input class="form-control" type="text" id="last_name" name="last_name" value="{{ group.leader.last_name or last_name }}" />
     </div>
-</div>
+  </div>
 
-<div class="form-group">
-    <label class="col-sm-2 control-label">Email</label>
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="email">Email</label>
     <div class="col-sm-6">
-        <input class="focus" type="text" name="email" value="{{ email }}" />
+      <input class="form-control" type="text" id="email" name="email" value="{{ group.leader.email or email }}" />
     </div>
-</div>
+  </div>
 
-
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" value="Upload">Save</button>
+  <div class="form-group">
+    <div class="col-sm-6 col-sm-offset-3">
+      <button type="submit" class="btn btn-primary" value="Upload">Create Band</button>
     </div>
-</div>
+  </div>
 </form>
 {% endblock %}

--- a/bands/templates/band_admin/add_band.html
+++ b/bands/templates/band_admin/add_band.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Group Form{% endblock %}
+{% block content %}
+    <div class="panel panel-default">
+<div class="panel-body">
+
+<h2> Group Info </h2>
+
+<div style="text-align:center">
+    <a href="index">Return to group list</a>
+</div>
+<form method="post" action="add_band" class="form-horizontal">
+{{ csrf_token() }}
+<input type="hidden" name="id" value="{{ group.db_id }}" />
+    <div class="form-group">
+    <label class="col-sm-2 control-label">Name of Group</label>
+    <div class="col-sm-6">
+        <input class="focus" type="text" name="name" value="{{ group.name }}" />
+    </div>
+</div>
+
+    <div class="form-group">
+    <label class="col-sm-2 control-label">Badges</label>
+    <div class="col-sm-6">
+        <select name="badges">
+            {{ int_options(1, c.MAX_GROUP_SIZE, group.badges) }}
+        </select>
+        {% if not group.is_new %}
+            [{{ group.badges_purchased }} badge(s) purchased]
+        {% endif %}
+    </div>
+</div>
+
+{% include "groupextra.html" %}
+
+<div class="form-group">
+    <label class="col-sm-2 control-label">Admin Notes</label>
+    <div class="col-sm-6">
+        <textarea name="admin_notes" rows="3" style="width:66%">{{ group.admin_notes }}</textarea>
+    </div>
+</div>
+
+    <h2>Leader Info</h2>
+<div class="form-group">
+    <label class="col-sm-2 control-label">First Name</label>
+    <div class="col-sm-6">
+        <input class="focus" type="text" name="first_name" value="{{ first_name }}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="col-sm-2 control-label">Last Name</label>
+    <div class="col-sm-6">
+        <input class="focus" type="text" name="last_name" value="{{ last_name }}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="col-sm-2 control-label">Email</label>
+    <div class="col-sm-6">
+        <input class="focus" type="text" name="email" value="{{ email }}" />
+    </div>
+</div>
+
+
+<div class="form-group">
+    <div class="col-sm-6 col-sm-offset-2">
+        <button type="submit" class="btn btn-primary" value="Upload">Save</button>
+    </div>
+</div>
+</form>
+{% endblock %}

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -9,7 +9,7 @@
 </style>
 
 <h2>Bands and Other Groups</h2>
-
+<div><a href="add_band"><input type="button" value="Add A Band"/></a></div>
 <div><input type="checkbox" id="only-bands" /> Show only bands</div>
 
 <table class="datatable" data-page-length="-1">

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -2,17 +2,21 @@
 {% block title %}Band Admin{% endblock %}
 {% block content %}
 
-<style type="text/css">
-    .datatable td, .datatable th {
-        padding: 5px 20px 5px 20px;
-    }
+<style>
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.dataTables_length .dataTables_addon {
+  margin-left: 25px;
+}
 </style>
 
-<h2>Bands and Other Groups</h2>
-<div><a href="add_band"><input type="button" value="Add A Band"/></a></div>
-<div><input type="checkbox" id="only-bands" /> Show only bands</div>
+<h1>Bands and Other Groups <a class="btn btn-primary" href="add_band">Add a Band</a></h1>
 
-<table class="datatable" data-page-length="-1">
+<div class="table-responsive">
+  <table class="datatable table table-striped" data-page-length="-1">
     <thead>
         <tr>
             <th>Group</th>
@@ -33,9 +37,11 @@
             <td><a href="../groups/form?id={{ group.id }}">{{ group.name }}</a></td>
             <td class="band">
                 {% if group.band %}
-                   <button onClick="removeAsBand('{{ group.id }}')">Remove as a Band</button><br><a href="band_info?id={{ group.band.id }}">Band Info</a>
+                    <button class="btn btn-sm btn-warning" onClick="removeAsBand('{{ group.id }}')">Unmark as a Band</button>
+                    <br>
+                    <a href="band_info?id={{ group.band.id }}">Band Info</a>
                 {% else %}
-                    <button onClick="markAsBand('{{ group.id }}')">Mark as a Band</button>
+                    <button class="btn btn-sm btn-primary" onClick="markAsBand('{{ group.id }}')">Mark as a Band</button>
                 {% endif %}
             </td>
             <td>{% if group.band.panel %}{{ group.band.panel.completed|yesno("Y,") }}{% endif %}</td>
@@ -49,13 +55,15 @@
         </tr>
     {% endfor %}
     </tbody>
-</table>
+  </table>
+</div>
 
-<p><a href="everything">Click to export all band data as a CSV file</a></p>
+<p><a href="everything">Export all band data as a CSV file</a></p>
 
 <script>
     var markAsBand = function (groupId) {
-        var $band = $('#' + groupId).find('.band').text('Marking...');
+        var $band = $('#' + groupId).find('.band'),
+            $button = $band.find('.btn').prop('disabled', true).text('Marking...');
         $.ajax({
             method: 'POST',
             url: 'mark_as_band',
@@ -66,7 +74,9 @@
             success: function (response) {
                 if (response.id) {
                     $band.empty().append(
-                        $('<a>Band Info</a>').attr('href', 'band_info?id=' + response.id)
+                        '<button class="btn btn-sm btn-warning" onClick="removeAsBand(\'' + groupId + '\')">Unmark as a Band</button>' +
+                        '<br>' +
+                        '<a href="band_info?id=' + response.id + '">Band Info</a>'
                     ).parents('tr').removeClass('nonband').addClass('band');
                 }
                 toastr.info(response.message);
@@ -74,7 +84,8 @@
         });
     };
     var removeAsBand = function (groupId) {
-        var $band = $('#' + groupId).find('.band').text('Removing...');
+        var $band = $('#' + groupId).find('.band'),
+            $button = $band.find('.btn').prop('disabled', true).text('Unmarking...');
         $.ajax({
             method: 'POST',
             url: 'remove_as_band',
@@ -85,16 +96,23 @@
             success: function (response) {
                 if (response.id) {
                     $band.empty().append(
-                        $('<button>Mark as a Band</button>').attr('onClick', 'markAsBand(\'' + response.id + '\')')
+                        '<button class="btn btn-sm btn-primary" onClick="markAsBand(\'' + response.id + '\')">Mark as a Band</button>'
                     ).parents('tr').removeClass('band').addClass('nonband');
                 }
                 toastr.info(response.message);
             }
         });
     };
-    $(function () {
-        var $onlyBands = $('#only-bands').on('click', function () {
-            setVisible('.nonband', !$onlyBands.prop('checked'))
+    $(document).ready(function() {
+        $(window).load(function() {
+            $('.dataTables_length').append(
+                '<label class="dataTables_addon">' +
+                '<input type="checkbox" id="only-bands" /> Show only bands' +
+                '</label>');
+
+            var $onlyBands = $('#only-bands').on('click', function () {
+                setVisible('.nonband', !$onlyBands.prop('checked'))
+            });
         });
     });
 </script>

--- a/bands/tests/test_band_admin.py
+++ b/bands/tests/test_band_admin.py
@@ -1,0 +1,106 @@
+import re
+
+import cherrypy
+import pytest
+from uber.utils import CSRFException
+
+from bands import *
+from bands.site_sections import band_admin
+
+
+def _extract_message_from_html(html):
+    match = re.search(r"var message = '(.*)';", html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture()
+def GET(monkeypatch):
+    monkeypatch.setattr(cherrypy.request, 'method', 'GET')
+
+
+@pytest.fixture()
+def POST(monkeypatch):
+    monkeypatch.setattr(cherrypy.request, 'method', 'POST')
+
+
+@pytest.fixture()
+def csrf_token(monkeypatch):
+    token = '4a2cc6f4-bf9f-49d2-a925-00ff4e22ae4a'
+    monkeypatch.setitem(cherrypy.session, 'csrf_token', token)
+    monkeypatch.setitem(cherrypy.request.headers, 'CSRF-Token', token)
+    yield token
+
+
+@pytest.fixture()
+def admin_attendee():
+    with Session() as session:
+        session.insert_test_admin_account()
+
+    with Session() as session:
+        attendee = session.query(Attendee).filter(
+            Attendee.email == 'magfest@example.com').one()
+        cherrypy.session['account_id'] = attendee.admin_account.id
+        yield attendee
+        cherrypy.session['account_id'] = None
+        session.delete(attendee)
+
+
+class TestAddBand(object):
+
+    def _add_band_response(self, **params):
+        response = band_admin.Root().add_band(**params)
+        if isinstance(response, bytes):
+            response = response.decode('utf-8')
+        response = response.strip()
+        assert response.startswith('<!DOCTYPE HTML>')
+        return response
+
+    def test_GET(self, GET, admin_attendee):
+        response = self._add_band_response()
+        message = _extract_message_from_html(response)
+        assert message == ''
+
+    def test_POST_requires_csrf_token(self, POST, admin_attendee):
+        with pytest.raises(HTTPRedirect, match='CSRF'):
+            band_admin.Root().add_band()
+
+    @pytest.mark.parametrize('params,message_start', [
+        (dict(), 'Name, First Name, Last Name, and Email are'),
+        (dict(name='Group1', first_name='Al'), 'Last Name and Email are'),
+        (dict(name='Group1', first_name='Al', last_name='Bert'), 'Email is')])
+    def test_POST_required_fields(
+            self, POST, csrf_token, admin_attendee, params, message_start):
+        response = self._add_band_response(**params)
+        message = _extract_message_from_html(response)
+        assert message.startswith(message_start)
+
+        with Session() as session:
+            assert session.query(Group).filter(
+                Group.name == 'Group1').first() is None
+
+    def test_POST_creates_group(self, POST, csrf_token, admin_attendee):
+        with pytest.raises(HTTPRedirect, match='Group1 has been uploaded'):
+            response = self._add_band_response(
+                name='Group1',
+                admin_notes='Stuff',
+                first_name='Al',
+                last_name='Bert',
+                email='al@example.com',
+                badges=4)
+
+        with Session() as session:
+            group = session.query(Group).filter(Group.name == 'Group1').first()
+            assert group
+            assert group.auto_recalc == False
+            assert group.admin_notes == 'Stuff'
+            assert group.leader
+            assert group.leader.first_name == 'Al'
+            assert group.leader.last_name == 'Bert'
+            assert group.leader.email == 'al@example.com'
+            assert group.leader.placeholder == True
+            assert group.band
+            assert group.badges == 4
+            for attendee in group.attendees:
+                assert attendee.paid == c.NEED_NOT_PAY
+                assert attendee.badge_type == c.ATTENDEE_BADGE
+                assert attendee.ribbon == c.BAND

--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -1,0 +1,19 @@
+
+[enums]
+[[badge]]
+attendee_badge = "Attendee"
+child_badge = "Minor"
+supporter_badge = "Supporter"
+staff_badge = "Staff"
+guest_badge = "Guest"
+one_day_badge = "One Day"
+
+[[ribbon]]
+no_ribbon = "no ribbon"
+volunteer_ribbon = "Volunteer"
+dept_head_ribbon = "Department Head"
+dealer_ribbon = "Shopkeep"
+panelist_ribbon = "Panelist"
+band = "RockStar"
+over_13 = "Between 13 and 18 (unused)"
+under_13 = "Under 13"


### PR DESCRIPTION
This branch will add a page under `band_admin/add_band` which will automate the workflow as described in issue #51. 

This also adds a button to `band_admin/index`. Please please please suggest changes to the UI or code. Teamwork makes the dreamwork. Also, I am unsure what the unit test for this would look like code-wise. Still getting the hang of them.

<img width="532" alt="band5" src="https://cloud.githubusercontent.com/assets/6538753/26745962/05294776-47a2-11e7-8925-d3e546881c71.png">

<img width="852" alt="band6" src="https://cloud.githubusercontent.com/assets/6538753/26745964/0657a78c-47a2-11e7-8bdc-3dd40edfd832.png">
