### PR TITLE
Improve band_admin index page to list status of items

### DIFF
--- a/bands/automated_emails.py
+++ b/bands/automated_emails.py
@@ -14,29 +14,29 @@ class BandEmail(AutomatedEmail):
 BandEmail('{EVENT_NAME} Performer Checklist', 'band_notification.txt', ident='band_checklist_inquiry')
 
 BandEmail('Last chance to apply for a {EVENT_NAME} Panel', 'band_panel_reminder.txt',
-          lambda b: not b.completed('panel'), when=days_before(3, c.BAND_PANEL_DEADLINE),
+          lambda b: not b.status('panel'), when=days_before(3, c.BAND_PANEL_DEADLINE),
           ident='band_panel_reminder')
 
 BandEmail('Last Chance to accept your offer to perform at {EVENT_NAME}', 'band_agreement_reminder.txt',
-          lambda b: not b.completed('info'), when=days_before(3, c.BAND_AGREEMENT_DEADLINE),
+          lambda b: not b.status('info'), when=days_before(3, c.BAND_AGREEMENT_DEADLINE),
           ident='band_agreement_reminder')
 
 BandEmail('Last chance to include your bio info on the {EVENT_NAME} website', 'band_bio_reminder.txt',
-          lambda b: not b.completed('bio'), when=days_before(3, c.BAND_BIO_DEADLINE),
+          lambda b: not b.status('bio'), when=days_before(3, c.BAND_BIO_DEADLINE),
           ident='band_bio_reminder')
 
 BandEmail('{EVENT_NAME} W9 reminder', 'band_w9_reminder.txt',
-          lambda b: b.payment and not b.completed('taxes'), when=days_before(3, c.BAND_W9_DEADLINE),
+          lambda b: b.payment and not b.status('taxes'), when=days_before(3, c.BAND_W9_DEADLINE),
           ident='band_w9_reminder')
 
 BandEmail('Last chance to sign up for selling merchandise at {EVENT_NAME}', 'band_merch_reminder.txt',
-          lambda b: not b.completed('merch'), when=days_before(3, c.BAND_MERCH_DEADLINE),
+          lambda b: not b.status('merch'), when=days_before(3, c.BAND_MERCH_DEADLINE),
           ident='band_merch_reminder')
 
 BandEmail('{EVENT_NAME} charity auction reminder', 'band_charity_reminder.txt',
-          lambda b: not b.completed('charity'), when=days_before(3, c.BAND_CHARITY_DEADLINE),
+          lambda b: not b.status('charity'), when=days_before(3, c.BAND_CHARITY_DEADLINE),
           ident='band_charity_reminder')
 
 BandEmail('{EVENT_NAME} stage plot reminder', 'band_stage_plot_reminder.txt',
-          lambda b: not b.completed('stage_plot'), when=days_before(3, c.STAGE_AGREEMENT_DEADLINE),
+          lambda b: not b.status('stage_plot'), when=days_before(3, c.STAGE_AGREEMENT_DEADLINE),
           ident='band_stage_plot_reminder')

--- a/bands/models.py
+++ b/bands/models.py
@@ -136,7 +136,7 @@ class BandTaxes(MagModel):
 
     @property
     def status(self):
-        return 'Yes <a href="{}">(view file)</a>'.format(self.w9_url) if self.w9_filename else ''
+        return self.w9_url if self.w9_url else ''
 
 
 class BandStagePlot(MagModel):
@@ -162,7 +162,7 @@ class BandStagePlot(MagModel):
 
     @property
     def status(self):
-        return "Yes <a href='{}'>(view file)</a>".format(self.url) if self.uploaded_file else ''
+        return self.url if self.url else ''
 
 
 class BandPanel(MagModel):

--- a/bands/models.py
+++ b/bands/models.py
@@ -57,17 +57,19 @@ class Band(MagModel):
     def email(self):
         return self.group.email
 
-    def completed(self, model):
+    def status(self, model):
         """
-        This is a safe way to check if a step has been completed for a particular band. It checks for a custom
-        'completed' property for the step; if that doesn't exist, it will attempt to return an ID of the step.
+        This is a safe way to check if a step has been completed and what its status is for a particular band.
+        It checks for a custom 'status' property for the step; if that doesn't exist, it will attempt to return
+        "Completed" if an ID of the step exists.
 
         :param model: This should match one of the relationship columns in the Band class, e.g., 'bio' or 'stage_plot'
-        :return: Returns either the 'completed' property of the model, the model's ID for that band, or None.
+        :return: Returns either the 'status' property of the model, "Completed," or None.
         """
 
         subclass = getattr(self, model)
-        return getattr(subclass, 'completed', getattr(subclass, 'id')) if subclass else None
+        if getattr(subclass, 'id'):
+            return getattr(subclass, 'status', "Completed")
 
 
 class BandInfo(MagModel):
@@ -79,8 +81,8 @@ class BandInfo(MagModel):
     arrival_time = Column(UnicodeText)
 
     @property
-    def completed(self):
-        return self.poc_phone
+    def status(self):
+        return "Yes" if self.poc_phone else ""
 
 
 class BandBio(MagModel):
@@ -111,8 +113,8 @@ class BandBio(MagModel):
         return extension(self.pic_filename)
 
     @property
-    def completed(self):
-        return self.desc
+    def status(self):
+        return "Yes" if self.desc else ""
 
 
 class BandTaxes(MagModel):
@@ -133,8 +135,8 @@ class BandTaxes(MagModel):
         return extension(self.w9_filename)
 
     @property
-    def completed(self):
-        return self.w9_filename
+    def status(self):
+        return 'Yes <a href="{}">(view file)</a>'.format(self.w9_url) if self.w9_filename else ''
 
 
 class BandStagePlot(MagModel):
@@ -159,8 +161,8 @@ class BandStagePlot(MagModel):
         return extension(self.filename)
 
     @property
-    def completed(self):
-        return self.uploaded_file
+    def status(self):
+        return "Yes <a href='{}'>(view file)</a>".format(self.url) if self.uploaded_file else ''
 
 
 class BandPanel(MagModel):
@@ -172,8 +174,8 @@ class BandPanel(MagModel):
     tech_needs = Column(MultiChoice(c.TECH_NEED_OPTS))
 
     @property
-    def completed(self):
-        return self.wants_panel
+    def status(self):
+        return self.wants_panel_label
 
 
 class BandMerch(MagModel):
@@ -181,8 +183,8 @@ class BandMerch(MagModel):
     selling_merch = Column(Choice(c.BAND_MERCH_OPTS), nullable=True)
 
     @property
-    def completed(self):
-        return self.selling_merch
+    def status(self):
+        return self.selling_merch_label
 
 
 class BandCharity(MagModel):
@@ -191,5 +193,5 @@ class BandCharity(MagModel):
     desc = Column(UnicodeText)
 
     @property
-    def completed(self):
-        return self.donating
+    def status(self):
+        return self.donating_label

--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -75,7 +75,7 @@
         <div class="col-sm-6">
             {% if not band.payment %}
             This band isn't being paid and thus doesn't need a W9 tax form.
-            {% elif band.taxes.completed %}
+            {% elif band.taxes.status %}
             <a href="{{ band.taxes.w9_url }}">Click here to view the band's uploaded W9 tax form</a>
             {% else %}
             This band is supposed to be paid, but has not uploaded a W9 tax form yet.

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -21,14 +21,14 @@ h1 {
         <tr>
             <th>Group</th>
             <th>Band?</th>
-            <th>Panel</th>
-            <th>Bio Provided</th>
-            <th>Agreement Completed</th>
-            <th>W9 Uploaded</th>
-            <th>Merch</th>
-            <th>Charity</th>
-            <th>Badges Claimed</th>
-            <th>Stage Plans</th>
+            {% if c.BAND_PANEL_DEADLINE %}<th>Panel</th>{% endif %}
+            {% if c.BAND_BIO_DEADLINE %}<th>Bio Provided</th>{% endif %}
+            {% if c.BAND_AGREEMENT_DEADLINE %}<th>Agreement Completed</th>{% endif %}
+            {% if c.BAND_W9_DEADLINE %}<th>W9 Uploaded</th>{% endif %}
+            {% if c.BAND_MERCH_DEADLINE %}<th>Merch</th>{% endif %}
+            {% if c.BAND_CHARITY_DEADLINE %}<th>Charity</th>{% endif %}
+            {% if c.BAND_BADGE_DEADLINE %}<th>Badges Claimed</th>{% endif %}
+            {% if c.STAGE_AGREEMENT_DEADLINE %}<th>Stage Plans</th>{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -44,14 +44,16 @@ h1 {
                     <button class="btn btn-sm btn-primary" onClick="markAsBand('{{ group.id }}')">Mark as a Band</button>
                 {% endif %}
             </td>
-            <td>{% if group.band.panel %}{{ group.band.panel.completed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.bio %}{{ group.band.bio.completed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.info %}{{ group.band.info.completed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.taxes %}{% if group.band.taxes.completed or not group.band.payment %}Y{% endif %}{% endif %}</td>
-            <td>{% if group.band.merch %}{{ group.band.merch.completed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.charity %}{{ group.band.charity.completed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.all_badges_claimed %}{{ group.band.all_badges_claimed|yesno("Y,") }}{% endif %}</td>
-            <td>{% if group.band.stage_plot %}{{ group.band.stage_plot.completed|yesno("Y,") }}{% endif %}</td>
+            {% if c.BAND_PANEL_DEADLINE %}<td>{% if group.band.panel %}{{ group.band.panel.status }}{% endif %}</td>{% endif %}
+            {% if c.BAND_BIO_DEADLINE %}<td>{% if group.band.bio %}{{ group.band.bio.status }}{% endif %}</td>{% endif %}
+            {% if c.BAND_AGREEMENT_DEADLINE %}<td>{{ group.band.info.status }}</td>{% endif %}
+            {% if c.BAND_W9_DEADLINE %}<td>
+                {% if not group.band.payment %}Not Needed
+                {% else %}{{ group.band.taxes.status|safe }}{% endif %}</td>{% endif %}
+            {% if c.BAND_MERCH_DEADLINE %}<td>{{ group.band.merch.status }}</td>{% endif %}
+            {% if c.BAND_CHARITY_DEADLINE %}<td>{{ group.band.charity.status }}</td>{% endif %}
+            {% if c.BAND_BADGE_DEADLINE %}<td>{{ group.band.all_badges_claimed|yesno("Yes,") }}</td>{% endif %}
+            {% if c.STAGE_AGREEMENT_DEADLINE %}<td>{{ group.band.stage_plot.status|safe }}</td>{% endif %}
         </tr>
     {% endfor %}
     </tbody>

--- a/bands/templates/band_admin/index.html
+++ b/bands/templates/band_admin/index.html
@@ -49,11 +49,11 @@ h1 {
             {% if c.BAND_AGREEMENT_DEADLINE %}<td>{{ group.band.info.status }}</td>{% endif %}
             {% if c.BAND_W9_DEADLINE %}<td>
                 {% if not group.band.payment %}Not Needed
-                {% else %}{{ group.band.taxes.status|safe }}{% endif %}</td>{% endif %}
+                {% else %}{{ group.band.taxes.status|url_to_link("Yes", "_blank") }}{% endif %}</td>{% endif %}
             {% if c.BAND_MERCH_DEADLINE %}<td>{{ group.band.merch.status }}</td>{% endif %}
             {% if c.BAND_CHARITY_DEADLINE %}<td>{{ group.band.charity.status }}</td>{% endif %}
-            {% if c.BAND_BADGE_DEADLINE %}<td>{{ group.band.all_badges_claimed|yesno("Yes,") }}</td>{% endif %}
-            {% if c.STAGE_AGREEMENT_DEADLINE %}<td>{{ group.band.stage_plot.status|safe }}</td>{% endif %}
+            {% if c.BAND_BADGE_DEADLINE %}<td>{{ group.unregistered_badges ~ " Unclaimed" if group.unregistered_badges else "Yes" }}</td>{% endif %}
+            {% if c.STAGE_AGREEMENT_DEADLINE %}<td>{{ group.band.stage_plot.status|url_to_link("Yes", "_blank") }}</td>{% endif %}
         </tr>
     {% endfor %}
     </tbody>

--- a/bands/templates/bands/index.html
+++ b/bands/templates/bands/index.html
@@ -18,13 +18,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.BAND_PANEL_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.panel.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.panel.status) }}</td>
         <td><b><a href="panel?band_id={{ band.id }}">Want a Panel?</a></b></td>
         <td><i>Deadline:</i> {{ c.BAND_PANEL_DEADLINE|datetime_local }}</td>
     </tr>
     <tr>
         <td colspan="3">
-            {% if not band.panel.completed %}
+            {% if not band.panel.status %}
                 Please use the above link to let us know whether or not you are interested in also running a panel.
                 We cannot accommodate all requests, but we definitely want to hear your ideas!
             {% elif band.panel.wants_panel %}
@@ -40,13 +40,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.BAND_BIO_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.bio.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.bio.status) }}</td>
         <td><b><a href="bio?band_id={{ band.id }}">Completed Band Bio</a></b></td>
         <td><i>Deadline:</i> {{ c.BAND_BIO_DEADLINE|datetime_local }}</td>
     </tr>
     <tr>
         <td colspan="3">
-            {% if band.bio.completed %}
+            {% if band.bio.status %}
                 You have already provided us with your bio information, but you can use the link above to update it.
                 {% if not band.bio.uploaded_pic %}
                     We encourage you to upload a bio pic for your band (which you have NOT yet done) so that we can
@@ -62,13 +62,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.BAND_AGREEMENT_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.info.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.info.status) }}</td>
         <td><b><a href="agreement?band_id={{ band.id }}">Completed Band Agreement</a></b></td>
         <td><i>Deadline:</i> {{ c.BAND_AGREEMENT_DEADLINE|datetime_local }}</td>
     </tr>
     <tr>
         <td colspan="3">
-            {% if band.info.completed %}
+            {% if band.info.status %}
                 You have already provided all the information required as part of your band agreement.  You may edit your
                 information (e.g. if you've discovered that you'll be arriving on a different day or time) using the link above.
             {% else %}
@@ -81,13 +81,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if band.payment and c.BAND_W9_DEADLINE %}
         <tr>
-            <td width="25">{{ macros.checklist_image(band.taxes.completed) }}</td>
+            <td width="25">{{ macros.checklist_image(band.taxes.status) }}</td>
             <td><b><a href="w9?band_id={{ band.id }}">Completed W9</a></b></td>
             <td><i>Deadline:</i> {{ c.BAND_W9_DEADLINE|datetime_local }}</td>
         </tr>
         <tr>
             <td colspan="3">
-                {% if band.taxes.completed %}
+                {% if band.taxes.status %}
                     You have already uploaded your W9 form, but if you need to make changes you can upload a new one
                     using the link above.
                 {% else %}
@@ -100,13 +100,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.BAND_MERCH_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.merch.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.merch.status) }}</td>
         <td><b><a href="merch?band_id={{ band.id }}">Selling Merchandise</a></b></td>
         <td><i>Deadline:</i> {{ c.BAND_MERCH_DEADLINE|datetime_local }}</td>
     </tr>
     <tr>
         <td colspan="3">
-            {% if band.merch.completed %}
+            {% if band.merch.status %}
                 You have already indicated your merchandise preferences, but you may update them using the link above.
             {% else %}
                 We need you to tell us whether you have any merchandise to sell{% if c.ROCK_ISLAND %}, and whether you intend to participate in
@@ -119,13 +119,13 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.BAND_CHARITY_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.charity.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.charity.status) }}</td>
         <td><b><a href="charity?band_id={{ band.id }}">Donating to our Charity Auction</a></b></td>
         <td><i>Deadline:</i> {{ c.BAND_CHARITY_DEADLINE|datetime_local }}</td>
     </tr>
     <tr>
         <td colspan="3">
-            {% if band.charity.completed %}
+            {% if band.charity.status %}
                 You have already indicated your charity preferences, but you may update them using the link above.
             {% else %}
                 {{ c.EVENT_NAME }} runs a yearly charity auction, and we need you to tell us whether you can contribute any
@@ -162,7 +162,7 @@ Here is a list of things which {{ c.EVENT_NAME }} needs from you before the even
 
     {% if c.STAGE_AGREEMENT_DEADLINE %}
     <tr>
-        <td width="25">{{ macros.checklist_image(band.stage_plot.completed) }}</td>
+        <td width="25">{{ macros.checklist_image(band.stage_plot.status) }}</td>
         <td><b><a href="stage_plot?band_id={{ band.id }}">Stage Layouts</a></b></td>
         <td><i>Deadline:</i> {{ c.STAGE_AGREEMENT_DEADLINE|datetime_local }}</td>
     </tr>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2543 by passing specific representations of items' statuses to the template, instead of just a boolean indicating whether or not the item exists. We can still use these as booleans for the band checklist, because they will only be falsey if the step isn't completed.