### PR TITLE
Stop adding c.BAND ribbon to new bands

### DIFF
--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -26,7 +26,7 @@ class Root:
             if not message:
                 group.auto_recalc = False
                 session.add(group)
-                message = session.assign_badges(group, params.get('badges', 1), new_ribbon_type=c.BAND, paid=c.PAID_BY_GROUP)
+                message = session.assign_badges(group, params.get('badges', 1), paid=c.PAID_BY_GROUP)
             if not message:
                 session.commit()
                 leader = group.leader = group.attendees[0]

--- a/bands/tests/test_band_admin.py
+++ b/bands/tests/test_band_admin.py
@@ -104,4 +104,3 @@ class TestAddBand(object):
             for attendee in group.attendees:
                 assert attendee.paid == c.PAID_BY_GROUP
                 assert attendee.badge_type == c.ATTENDEE_BADGE
-                assert attendee.ribbon == c.BAND


### PR DESCRIPTION
The c.BAND ribbon is a 'non-canonical' ribbon -- it's not part of our default config. Since marking a group as a band doesn't change anyone's ribbon type, it's best to just not apply ribbons during group creation.

Before we merge this, we should ask the events' music departments what they think.