### PR TITLE
Fix 500 errors when sending band emails

### DIFF
--- a/bands/models.py
+++ b/bands/models.py
@@ -68,8 +68,7 @@ class Band(MagModel):
         """
 
         subclass = getattr(self, model)
-        if getattr(subclass, 'id'):
-            return getattr(subclass, 'status', "Completed")
+        return getattr(subclass, 'completed', getattr(subclass, 'id')) if subclass else None
 
 
 class BandInfo(MagModel):


### PR DESCRIPTION
Reverts default `status` property to work as the `completed` property did before. The new way is causing email errors.