### PR TITLE
Add custom, admin-friendly filenames to downloaded files

### DIFF
--- a/bands/models.py
+++ b/bands/models.py
@@ -59,7 +59,10 @@ class Band(MagModel):
 
     @property
     def normalized_group_name(self):
-        return ''.join(e for e in self.group.name.strip().lower() if e.isalnum() or e == ' ').replace(' ', '_')
+        # Remove all special characters, then remove all extra whitespace, then replace spaces with underscores
+        return ' '.join(
+            ''.join(e for e in self.group.name.strip().lower() if e.isalnum() or e == ' ').split()
+        ).replace(' ', '_')
 
     def status(self, model):
         """

--- a/bands/models.py
+++ b/bands/models.py
@@ -57,6 +57,10 @@ class Band(MagModel):
     def email(self):
         return self.group.email
 
+    @property
+    def normalized_group_name(self):
+        return ''.join(e for e in self.group.name.strip().lower() if e.isalnum() or e == ' ').replace(' ', '_')
+
     def status(self, model):
         """
         This is a safe way to check if a step has been completed and what its status is for a particular band.
@@ -113,6 +117,10 @@ class BandBio(MagModel):
         return extension(self.pic_filename)
 
     @property
+    def download_filename(self):
+        return self.band.normalized_group_name + "_bio_pic." + self.pic_extension
+
+    @property
     def status(self):
         return "Yes" if self.desc else ""
 
@@ -133,6 +141,10 @@ class BandTaxes(MagModel):
     @property
     def w9_extension(self):
         return extension(self.w9_filename)
+
+    @property
+    def download_filename(self):
+        return self.band.normalized_group_name + "_w9_form." + self.w9_extension
 
     @property
     def status(self):
@@ -159,6 +171,10 @@ class BandStagePlot(MagModel):
     @property
     def stage_plot_extension(self):
         return extension(self.filename)
+
+    @property
+    def download_filename(self):
+        return self.band.normalized_group_name + "_stage_plot." + self.stage_plot_extension
 
     @property
     def status(self):

--- a/bands/site_sections/bands.py
+++ b/bands/site_sections/bands.py
@@ -169,12 +169,12 @@ class Root:
 
     def view_bio_pic(self, session, id):
         band = session.band(id)
-        return serve_file(band.bio.pic_fpath, name=band.bio.pic_filename, content_type=band.bio.pic_content_type)
+        return serve_file(band.bio.pic_fpath, disposition="attachment", name=band.bio.download_filename, content_type=band.bio.pic_content_type)
 
     def view_w9(self, session, id):
         band = session.band(id)
-        return serve_file(band.taxes.w9_fpath, name=band.taxes.w9_filename, content_type=band.taxes.w9_content_type)
+        return serve_file(band.taxes.w9_fpath, disposition="attachment", name=band.taxes.download_filename, content_type=band.taxes.w9_content_type)
 
     def view_stage_plot(self, session, id):
         band = session.band(id)
-        return serve_file(band.stage_plot.fpath, name=band.stage_plot.filename, content_type=band.stage_plot.content_type)
+        return serve_file(band.stage_plot.fpath, disposition="attachment", name=band.stage_plot.download_filename, content_type=band.stage_plot.content_type)

--- a/bands/tests/models/test_band.py
+++ b/bands/tests/models/test_band.py
@@ -1,0 +1,9 @@
+import pytest
+
+from bands import *
+
+
+class TestBandProperties:
+    def test_normalized_group_name(self):
+        group = Group(name="$Test's Cool Band &     Friends#%@", band=Band())
+        assert group.band.normalized_group_name == "tests_cool_band_friends"


### PR DESCRIPTION
Fixes https://github.com/magfest/bands/issues/77 by:
1) fixing a bug where the view's name was used because we forgot to provide a disposition to our file serving function, and 
2) adding a custom filename to use so admins don't get the random filenames uploaded by bands (e.g., band_name_bio_pic.png vs my_best_selfie.png)