### PR TITLE
allow admins to specify # of hotel rooms for band contracts

### DIFF
--- a/alembic/versions/edd7b60ea4b4_add_per_band_hotel_room_count.py
+++ b/alembic/versions/edd7b60ea4b4_add_per_band_hotel_room_count.py
@@ -1,0 +1,38 @@
+"""Add per-band hotel room count
+
+Revision ID: edd7b60ea4b4
+Revises: fc791d73e762
+Create Date: 2017-06-22 15:36:41.797478
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'edd7b60ea4b4'
+down_revision = 'fc791d73e762'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+
+def upgrade():
+    op.add_column('band', sa.Column('num_hotel_rooms', sa.Integer(), server_default='1', nullable=False))
+
+
+def downgrade():
+    op.drop_column('band', 'num_hotel_rooms')

--- a/bands/models.py
+++ b/bands/models.py
@@ -36,6 +36,7 @@ class Band(MagModel):
     merch = relationship('BandMerch', backref=backref('band', load_on_pending=True), uselist=False)
     charity = relationship('BandCharity', backref=backref('band', load_on_pending=True), uselist=False)
 
+    num_hotel_rooms = Column(Integer, default=1, admin_only=True)
     payment = Column(Integer, default=0, admin_only=True)
     vehicles = Column(Integer, default=1, admin_only=True)
     estimated_loadin_minutes = Column(Integer, default=c.DEFAULT_LOADIN_MINUTES, admin_only=True)

--- a/bands/site_sections/band_admin.py
+++ b/bands/site_sections/band_admin.py
@@ -94,7 +94,7 @@ class Root:
     def everything(self, out, session):
         out.writerow([
             'Group Name', 'Primary Contact Email',
-            'Payment', 'Vehicles', 'Load-In', 'Performance Time',
+            'Payment', 'Vehicles', 'Hotel Rooms', 'Load-In', 'Performance Time',
             'PoC Cellphone', 'Performer Count', 'Bringing Vehicle', 'Vehicle Info', 'Arrival Time',
             'Bio', 'Website', 'Facebook', 'Twitter', 'Other Social Media', 'Bio Pic',
             'Wants Panel', 'Panel Name', 'Panel Description', 'Panel Length', 'Panel Tech Needs',
@@ -108,7 +108,7 @@ class Root:
             absolute_stageplot_url = convert_to_absolute_url(getattr(band.stage_plot, 'url', ''))
             out.writerow([
                 band.group.name, band.email,
-                band.payment, band.vehicles, band.estimated_loadin_minutes, band.estimated_performance_minutes,
+                band.payment, band.vehicles, band.num_hotel_rooms, band.estimated_loadin_minutes, band.estimated_performance_minutes,
                 getattr(band.info, 'poc_phone', ''), getattr(band.info, 'performer_count', ''), getattr(band.info, 'bringing_vehicle', ''), getattr(band.info, 'vehicle_info', ''), getattr(band.info, 'arrival_time', ''),
                 getattr(band.bio, 'desc', ''), getattr(band.bio, 'website', ''), getattr(band.bio, 'facebook', ''), getattr(band.bio, 'twitter', ''), getattr(band.bio, 'other_social_media', ''), absolute_pic_url,
                 getattr(band.panel, 'wants_panel', ''), getattr(band.panel, 'name', ''), getattr(band.panel, 'length', ''), getattr(band.panel, 'desc', ''), ' / '.join(getattr(band.panel, 'panel_tech_needs_labels', '')),

--- a/bands/templates/band_admin/band_info.html
+++ b/bands/templates/band_admin/band_info.html
@@ -214,6 +214,16 @@
     </div>
 
     <div class="row">
+        <label class="col-sm-2 control-label">Hotel Rooms:</label>
+        <div class="col-sm-6">
+            <input type="number" class="form-control" name="num_hotel_rooms" value="{{ band.num_hotel_rooms }}" />
+            <p class="help-text">
+                How many hotel rooms are we offering the band.
+            </p>
+        </div>
+    </div>
+
+    <div class="row">
         <label class="col-sm-2 control-label">Load-In length:</label>
         <div class="col-sm-6">
             <input type="number" class="form-control" name="estimated_loadin_minutes" value="{{ band.estimated_loadin_minutes }}" />

--- a/bands/templates/bands/agreement-base.html
+++ b/bands/templates/bands/agreement-base.html
@@ -67,15 +67,17 @@
 {% endblock %}
 
 {% block band_text_accommodations %}
-    <h3>
-        Accommodations
-    </h3>
-    <p>
-        {% block band_text_accommodations_inner %}
-        One hotel room with 2 queen beds will be provided,
-        with check in and out times provided as part of our final agreement.
-        {% endblock %}
-    </p>
+    {% if band.num_hotel_rooms > 0 %}
+        <h3>
+            Accommodations
+        </h3>
+        <p>
+            {% block band_text_accommodations_inner %}
+            {{ band.num_hotel_rooms }} hotel room{{ band.num_hotel_rooms|pluralize }} with 2 queen beds
+            will be provided, with check in and out times provided as part of our final agreement.
+            {% endblock %}
+        </p>
+    {% endif %}
 {% endblock %}
 
 {% block band_text_parking %}
@@ -84,7 +86,9 @@
     </h3>
     <p>
         {% block band_text_parking_inner %}
-        To be included with hotel room for <b>{{ band.vehicles }} vehicle{{ band.vehicles|pluralize }}</b>.
+        To be included
+        {% if band.num_hotel_rooms > 0 %}with hotel room{% endif %}
+        for <b>{{ band.vehicles }} vehicle{{ band.vehicles|pluralize }}</b>.
         {% endblock %}
     </p>
 {% endblock %}


### PR DESCRIPTION
fixes #57 

Previously, our contracts always assumed we were offering hotel rooms to each band.  Now, make this configurable for 0 or more hotel rooms.

What it looks like:

![image](https://user-images.githubusercontent.com/5413064/27452038-24665d14-575f-11e7-8a94-d9b5c069b285.png)

This also affects the band contract and the "hotel" section will be hidden if we are offering no rooms.