### PR TITLE
Convert to using a MultiChoice column for ribbons

### DIFF
--- a/bands/tests/test_band_admin.py
+++ b/bands/tests/test_band_admin.py
@@ -104,4 +104,4 @@ class TestAddBand(object):
             for attendee in group.attendees:
                 assert attendee.paid == c.PAID_BY_GROUP
                 assert attendee.badge_type == c.ATTENDEE_BADGE
-                assert attendee.ribbon == c.BAND
+                assert c.BAND in attendee.ribbon_ints

--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -9,7 +9,6 @@ guest_badge = "Guest"
 one_day_badge = "One Day"
 
 [[ribbon]]
-no_ribbon = "no ribbon"
 volunteer_ribbon = "Volunteer"
 dept_head_ribbon = "Department Head"
 dealer_ribbon = "Shopkeep"


### PR DESCRIPTION
Must be merged after https://github.com/magfest/ubersystem/pull/2711. Converts this plugin to using the syntax needed for the new MultiChoice ribbons.