### PR TITLE
Changes band w9 URL to accept both band_id and id

### DIFF
--- a/bands/site_sections/bands.py
+++ b/bands/site_sections/bands.py
@@ -59,7 +59,9 @@ class Root:
             'message': message
         }
 
-    def w9(self, session, band_id, message='', w9=None, **params):
+    def w9(self, session, band_id=None, id=None, message='', w9=None, **params):
+        band_id = band_id or id
+        assert band_id, 'Either a band_id or id is required'
         band = session.band(band_id)
         band_taxes = session.band_taxes(params, restricted=True)
         if cherrypy.request.method == 'POST':

--- a/bands/templates/emails/band_w9_reminder.txt
+++ b/bands/templates/emails/band_w9_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-For tax reasons, {{ c.EVENT_NAME }} requires a completed W9 from all of its performers.  You can download a blank form, fill it out, and upload the completed form at {{ c.URL_BASE }}/bands/w9?id={{ band.id }}
+For tax reasons, {{ c.EVENT_NAME }} requires a completed W9 from all of its performers.  You can download a blank form, fill it out, and upload the completed form at {{ c.URL_BASE }}/bands/w9?band_id={{ band.id }}
 
 Please upload your completed W9 no later than {{ c.BAND_W9_DEADLINE }}.
 


### PR DESCRIPTION
The w9 url only accepts `band_id` as a parameter. The problem with that is we've been sending out emails that use `id` as a parameter instead of `band_id`. So when the band tries to click on the URL in the email they received, they are rewarded with a nice big error.

I'd like to just switch the email to use the right parameter, but we've ALREADY sent those emails out. They exist in the wild. So, I've changed the w9 method to accept both `band_id` AND `id`.

I'm going to sleep, so if anyone happens to review this before I wake up, please change it as you see fit, merge it, and deploy it on my behalf. Because we have users out there clicking on bum links.