### PR TITLE
Update emails to bands to use the correct URLs

### DIFF
--- a/bands/templates/emails/band_agreement_reminder.txt
+++ b/bands/templates/emails/band_agreement_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-Congratulations on being accepted to perform at {{ c.EVENT_NAME }}!  We need you to confirm your acceptance of a performance slot by completing the band agreement at {{ c.URL_BASE }}/bands/agreement?id={{ band.id }}
+Congratulations on being accepted to perform at {{ c.EVENT_NAME }}!  We need you to confirm your acceptance of a performance slot by completing the band agreement at {{ c.URL_BASE }}/bands/agreement?band_id={{ band.id }}
 
 Failure to complete the band agreement by {{ c.BAND_AGREEMENT_DEADLINE|datetime_local }} may result in your slot being given to a different group.
 

--- a/bands/templates/emails/band_bio_reminder.txt
+++ b/bands/templates/emails/band_bio_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-Congratulations again on being accepted to perform at {{ c.EVENT_NAME }}!  We're putting together performer bios to put on our website, and you have not yet filled out this information.  You may do so at {{ c.URL_BASE }}/bands/bio?id={{ band.id }}
+Congratulations again on being accepted to perform at {{ c.EVENT_NAME }}!  We're putting together performer bios to put on our website, and you have not yet filled out this information.  You may do so at {{ c.URL_BASE }}/bands/bio?band_id={{ band.id }}
 
 Failing to share your bio information by {{ c.BAND_BIO_DEADLINE|datetime_local }} may result in your band's information not being included on our website.
 

--- a/bands/templates/emails/band_charity_reminder.txt
+++ b/bands/templates/emails/band_charity_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-{{ c.EVENT_NAME }} has a yearly charity auction with 100% of proceeds going to Child's Play, and we ask our bands to contribute signed merchandise to the auction.  Please tell us whether you are able to donate anything at {{ c.URL_BASE }}/bands/charity?id={{ band.id }}
+{{ c.EVENT_NAME }} has a yearly charity auction with 100% of proceeds going to Child's Play, and we ask our bands to contribute signed merchandise to the auction.  Please tell us whether you are able to donate anything at {{ c.URL_BASE }}/bands/charity?band_id={{ band.id }}
 
 To help us plan our charity auction, we ask that you please fill out this form no later than {{ c.BAND_CHARITY_DEADLINE|datetime_local }}.
 

--- a/bands/templates/emails/band_merch_reminder.txt
+++ b/bands/templates/emails/band_merch_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-{{ c.EVENT_NAME }} encourages performers to sell their merchandise throughout the event.  The best way to do this is to participate in "Rock Island", where our volunteers sell your merchandise at a booth which is staffed throughout the event.  Bands can opt to instead sell from their own dedicated table in the Marketplace if they are will to staff for at least 8 hours per day.  We need you to tell us which option you prefer by filling out the form at {{ c.URL_BASE }}/bands/rock_island?id={{ band.id }}
+{{ c.EVENT_NAME }} encourages performers to sell their merchandise throughout the event.  The best way to do this is to participate in "Rock Island", where our volunteers sell your merchandise at a booth which is staffed throughout the event.  Bands can opt to instead sell from their own dedicated table in the Marketplace if they are will to staff for at least 8 hours per day.  We need you to tell us which option you prefer by filling out the form at {{ c.URL_BASE }}/bands/merch?band_id={{ band.id }}
 
 Failing to fill out this form by {{ c.BAND_MERCH_DEADLINE|datetime_local }} forfeits the offer of a dedicated table and may interfere with our ability to accept your merchandise at Rock Island.
 

--- a/bands/templates/emails/band_panel_reminder.txt
+++ b/bands/templates/emails/band_panel_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-{{ c.EVENT_NAME }} is happy to have you performing, and we're wondering whether you're interested in also participating in any panels.  Many of our performers enjoy Q&A sessions or even giving their own presentations.  Please let us know whether or not you are interested in anything like this by filling out the form at {{ c.URL_BASE }}/bands/panel?id={{ band.id }}
+{{ c.EVENT_NAME }} is happy to have you performing, and we're wondering whether you're interested in also participating in any panels.  Many of our performers enjoy Q&A sessions or even giving their own presentations.  Please let us know whether or not you are interested in anything like this by filling out the form at {{ c.URL_BASE }}/bands/panel?band_id={{ band.id }}
 
 Please let us know whether or not you are interested by {{ c.BAND_PANEL_DEADLINE|datetime_local }}.  Anyone who doesn't let us know by this date will be too late to be included in our event planning.
 

--- a/bands/templates/emails/band_stage_plot_reminder.txt
+++ b/bands/templates/emails/band_stage_plot_reminder.txt
@@ -1,6 +1,6 @@
 {{ band.group.name }},
 
-In order to prepare for your performance at this upcoming {{ c.EVENT_NAME }}, we need you to upload an exact description of your desired stage layout, which you can do at {{ c.URL_BASE }}/bands/stage_plot?id={{ band.id }}
+In order to prepare for your performance at this upcoming {{ c.EVENT_NAME }}, we need you to upload an exact description of your desired stage layout, which you can do at {{ c.URL_BASE }}/bands/stage_plot?band_id={{ band.id }}
 
 Failure to provide exact stage directions may result in you not receiving the setup you expect or want.  Please provide this description no later than {{ c.STAGE_AGREEMENT_DEADLINE|datetime_local }}.
 


### PR DESCRIPTION
All emails to bands were using `id` as a parameter, but most of the URLs they pointed to actually only accept `band_id`. We'd better fix this before any more emails get approved or we'll have to do more PRs like https://github.com/magfest/bands/pull/83.